### PR TITLE
Added unwatch function to sharedData

### DIFF
--- a/index.js
+++ b/index.js
@@ -1048,7 +1048,11 @@
              * */
             'watch': function(prop, callback){
                 this.watcher.watch(this.data, prop, callback);
-            }
+            },
+		
+	    'unwatch': function(prop, callback){
+		this.watcher.unwatch(this.data, prop, callback);    
+	    }
         },
 
         /**


### PR DESCRIPTION
Simple unwatch function for the sharedData object based on watchJS. It is more coherent to use watch and unwatch in the same way, than accessing to the watcher object to unwatch property.